### PR TITLE
7 add keys for programs with additional settings

### DIFF
--- a/H3DS4965TACBE-80_configuration.yaml
+++ b/H3DS4965TACBE-80_configuration.yaml
@@ -15,6 +15,7 @@ command_line:
         - MachMd
         - PrNm
         - PrPh
+        - PrCode
         - Temp
         - SpinSp
         - RemTime

--- a/H3DS4965TACBE-80_configuration.yaml
+++ b/H3DS4965TACBE-80_configuration.yaml
@@ -65,11 +65,17 @@ template:
         icon: mdi:progress-star
         state: >
           {% set Prog = state_attr('sensor.candy_washer_dryer', 'PrNm') %}
+          {% set ProgC = state_attr('sensor.candy_washer_dryer', 'PrCode') %}
           {% if Prog == "2" %}Cotton
           {% elif Prog == "3" %}Eco 40-60
           {% elif Prog == "4" %}Cotton & Prewash
           {% elif Prog == "9" %}Wool & Soft Care
-          {% elif Prog == "10" %}Rapid 14'/30'/44'
+          {% elif Prog == "10" %}
+            {% if ProgC == "103" %}Rapid 14'
+            {% elif ProgC == "71" %}Rapid 30'
+            {% elif ProgC == "39" %}Rapid 44'
+            {% elif ProgC == "65" %}WiFi Command
+            {% else %}{{ ProgC }}
           {% elif Prog == "11" %}All in One 59'
           {% elif Prog == "12" %}Extra Care
           {% elif Prog == "13" %}Dry (Wool)

--- a/H3DS4965TACBE-80_configuration.yaml
+++ b/H3DS4965TACBE-80_configuration.yaml
@@ -71,11 +71,12 @@ template:
           {% elif Prog == "4" %}Cotton & Prewash
           {% elif Prog == "9" %}Wool & Soft Care
           {% elif Prog == "10" %}
-            {% if ProgC == "103" %}Rapid 14'
+            {% if ProgC == "39" %}Rapid 14'
             {% elif ProgC == "71" %}Rapid 30'
-            {% elif ProgC == "39" %}Rapid 44'
-            {% elif ProgC == "65" %}WiFi Command
+            {% elif ProgC == "103" %}Rapid 44'
+            {% elif ProgC == "65" %}Wifi Command
             {% else %}{{ ProgC }}
+            {% endif %}
           {% elif Prog == "11" %}All in One 59'
           {% elif Prog == "12" %}Extra Care
           {% elif Prog == "13" %}Dry (Wool)

--- a/H3DS4965TACBE-80_configuration.yaml
+++ b/H3DS4965TACBE-80_configuration.yaml
@@ -139,10 +139,15 @@ template:
           {% set DryT = state_attr('sensor.candy_washer_dryer', 'DryT') %}
           {% if DryT == None %}Off
           {% elif DryT == "0" %}Dry Off
-          {% elif DryT == "3" %}Iron Dry
-          {% elif DryT == "4" %}Dry Finished
-          {% elif DryT == "5" %}Dry Ending
-          {% else %}{{ DryT }}
+          {% elif DryT == "1" %}Extra Dry 
+          {% elif DryT == "2" %}Iron Dry
+          {% elif DryT == "3" %}Cupboard Dry
+          {% elif DryT == "5" %}120'
+          {% elif DryT == "6" %}90'
+          {% elif DryT == "7" %}60'
+          {% elif DryT == "8" %}30'
+          {% elif DryT == "9" %}Wool Dry
+          {% else %}{{ DryT | int // 60 }}
           {% endif %}
   - sensor:
       - name: 'Washer/Dryer - Delay Time'

--- a/candy.py
+++ b/candy.py
@@ -47,7 +47,7 @@ while tries < retries:
         decodedDict = json.loads(decoded)
         candyData = decodedDict.get('statusLavatrice')
         for k, v in candyData.items():
-            if k[0:3] != "Opt" and k[0:3] != "Rec" and k[0:3] != "Ste" and k[0:3] != "SLe" and k[0:3] != "Che" and k[0:3] != "PrC" and k[0:3] != "Lan" and k[0:3] != "Fil" and k[0:3] != "Det" and k[0:3] != "Sof" and k[0:3] != "DPr" and k[0:3] != "SPr" and k[0:3] != "Wat" and k[0:3] != "rED":
+            if k[0:3] != "Opt" and k[0:3] != "Rec" and k[0:3] != "Ste" and k[0:3] != "SLe" and k[0:3] != "Che" and k[0:3] != "Lan" and k[0:3] != "Fil" and k[0:3] != "Det" and k[0:3] != "Sof" and k[0:3] != "DPr" and k[0:3] != "SPr" and k[0:3] != "Wat" and k[0:3] != "rED":
                 if k == 'DelVal' and candyData[k] == '255':
                     candy['DelVal'] = '0'
                 else:


### PR DESCRIPTION
Changes to expand support for H3DS4965TACBE-80
- PrCode no longer filtered in python code for machines that use this.
- PrCode added as an attribute in yaml command_line sensor. 
- Updated logic for definitions of codes in yaml templates.